### PR TITLE
More intuitive timespan for example event

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -12,9 +12,9 @@ class MyApp extends StatelessWidget {
       title: 'Test event',
       description: 'example',
       location: 'Flutter app',
-      startDate: DateTime(2019, 2, 8, 16, 49),
-      endDate: DateTime(2019, 2, 9, 17, 01),
-      allDay: true,
+      startDate: DateTime.now(),
+      endDate: DateTime.now().add(Duration(days: 1)),
+      allDay: false,
     );
 
     return MaterialApp(


### PR DESCRIPTION
Create event from now to tomorrow is more intuitive for users as they will see it directly in their calendar.