### PR TITLE
Migrate null safety

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.5.0
+
+* Migrate to null safety (thanks to @nilsreichardt)
+
 ## 1.4.0
 
 * Add timezone support (thanks to @palmsnipe)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.5.0
+## 2.0.0
 
 * Migrate to null safety (thanks to @nilsreichardt)
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -5,7 +5,9 @@ import 'package:add_2_calendar/add_2_calendar.dart';
 void main() => runApp(MyApp());
 
 class MyApp extends StatelessWidget {
-  final GlobalKey<ScaffoldState> scaffoldState = GlobalKey();
+  final GlobalKey<ScaffoldMessengerState> scaffoldMessengerKey =
+      GlobalKey<ScaffoldMessengerState>();
+
   @override
   Widget build(BuildContext context) {
     Event event = Event(
@@ -18,18 +20,18 @@ class MyApp extends StatelessWidget {
     );
 
     return MaterialApp(
+      scaffoldMessengerKey: scaffoldMessengerKey,
       home: Scaffold(
-        key: scaffoldState,
         appBar: AppBar(
           title: const Text('Add event to calendar example'),
         ),
         body: Center(
-          child: RaisedButton(
-            child: Text('Add test event to device calendar'),
+          child: ElevatedButton(
+            child: const Text('Add test event to device calendar'),
             onPressed: () {
               Add2Calendar.addEvent2Cal(event).then((success) {
-                scaffoldState.currentState.showSnackBar(
-                    SnackBar(content: Text(success ? 'Success' : 'Error')));
+                scaffoldMessengerKey.currentState!.showSnackBar(
+                    SnackBar(content: Text(success! ? 'Success' : 'Error')));
               });
             },
           ),

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -8,62 +8,48 @@ packages:
       relative: true
     source: path
     version: "1.4.0"
-  archive:
-    dependency: transitive
-    description:
-      name: archive
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.0.11"
-  args:
-    dependency: transitive
-    description:
-      name: args
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.5.2"
   async:
     dependency: transitive
     description:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.4.0"
+    version: "2.5.0"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.5"
+    version: "2.1.0"
+  characters:
+    dependency: transitive
+    description:
+      name: characters
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.1.0"
   charcode:
     dependency: transitive
     description:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.2"
+    version: "1.2.0"
+  clock:
+    dependency: transitive
+    description:
+      name: clock
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.1.0"
   collection:
     dependency: transitive
     description:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.14.11"
-  convert:
-    dependency: transitive
-    description:
-      name: convert
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.1.1"
-  crypto:
-    dependency: transitive
-    description:
-      name: crypto
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.1.3"
+    version: "1.15.0"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -71,6 +57,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.1.2"
+  fake_async:
+    dependency: transitive
+    description:
+      name: fake_async
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.2.0"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -81,55 +74,27 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
-  image:
-    dependency: transitive
-    description:
-      name: image
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.1.4"
   matcher:
     dependency: transitive
     description:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.6"
+    version: "0.12.10"
   meta:
     dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.8"
+    version: "1.3.0"
   path:
     dependency: transitive
     description:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.6.4"
-  pedantic:
-    dependency: transitive
-    description:
-      name: pedantic
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.8.0+1"
-  petitparser:
-    dependency: transitive
-    description:
-      name: petitparser
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.4.0"
-  quiver:
-    dependency: transitive
-    description:
-      name: quiver
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "2.0.5"
+    version: "1.8.0"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -141,62 +106,56 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.5.5"
+    version: "1.8.0"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.9.3"
+    version: "1.10.0"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.1.0"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.5"
+    version: "1.1.0"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.11"
+    version: "0.2.19"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.6"
+    version: "1.3.0"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.8"
-  xml:
-    dependency: transitive
-    description:
-      name: xml
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "3.5.0"
+    version: "2.1.0"
 sdks:
-  dart: ">=2.4.0 <3.0.0"
+  dart: ">=2.12.0 <3.0.0"
+  flutter: ">=1.10.0"

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "1.4.0"
+    version: "2.0.0"
   async:
     dependency: transitive
     description:

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -3,7 +3,7 @@ description: Demonstrates how to use the add_2_calendar plugin.
 publish_to: 'none'
 
 environment:
-  sdk: ">=2.1.0 <3.0.0"
+  sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
   flutter:

--- a/lib/src/add_2_cal.dart
+++ b/lib/src/add_2_cal.dart
@@ -7,15 +7,15 @@ class Add2Calendar {
   static const MethodChannel _channel = const MethodChannel('flutter.javih.com/add_2_calendar');
 
   /// Add an Event (object) to user's default calendar.
-  static Future<bool> addEvent2Cal(Event event) async {
-    final bool isAdded = await _channel.invokeMethod('add2Cal', <String, dynamic>{
+  static Future<bool?> addEvent2Cal(Event event) async {
+    final bool? isAdded = await _channel.invokeMethod('add2Cal', <String, dynamic>{
       'title': event.title,
       'desc': event.description,
       'location': event.location,
       'startDate': event.startDate.millisecondsSinceEpoch,
       'endDate': event.endDate.millisecondsSinceEpoch,
       'timeZone': event.timeZone,
-      'alarmInterval': event.alarmInterval.inSeconds.toDouble(),
+      'alarmInterval': event.alarmInterval!.inSeconds.toDouble(),
       'allDay': event.allDay,
     });
     return isAdded;

--- a/lib/src/add_2_cal.dart
+++ b/lib/src/add_2_cal.dart
@@ -4,18 +4,20 @@ import 'package:add_2_calendar/src/model/event.dart';
 import 'package:flutter/services.dart';
 
 class Add2Calendar {
-  static const MethodChannel _channel = const MethodChannel('flutter.javih.com/add_2_calendar');
+  static const MethodChannel _channel =
+      const MethodChannel('flutter.javih.com/add_2_calendar');
 
   /// Add an Event (object) to user's default calendar.
   static Future<bool?> addEvent2Cal(Event event) async {
-    final bool? isAdded = await _channel.invokeMethod('add2Cal', <String, dynamic>{
+    final bool? isAdded =
+        await _channel.invokeMethod('add2Cal', <String, dynamic>{
       'title': event.title,
       'desc': event.description,
       'location': event.location,
       'startDate': event.startDate.millisecondsSinceEpoch,
       'endDate': event.endDate.millisecondsSinceEpoch,
       'timeZone': event.timeZone,
-      'alarmInterval': event.alarmInterval!.inSeconds.toDouble(),
+      'alarmInterval': event.alarmInterval?.inSeconds.toDouble(),
       'allDay': event.allDay,
     });
     return isAdded;

--- a/lib/src/model/event.dart
+++ b/lib/src/model/event.dart
@@ -6,14 +6,14 @@ class Event {
   DateTime startDate, endDate;
   bool allDay;
   //In iOS, you can set alert notification with duration. Ex. Duration(minutes:30) -> After30 min.
-  Duration alarmInterval; 
+  Duration? alarmInterval; 
 
   Event(
-      {@required this.title,
+      {required this.title,
       this.description = '',
       this.location = '',
-      @required this.startDate,
-      @required this.endDate,
+      required this.startDate,
+      required this.endDate,
       this.alarmInterval,
       this.timeZone = '',
       this.allDay = false});

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: add_2_calendar
 description: A really simple Flutter plugin to add events to each platform's default calendar.
-version: 1.4.0
+version: 1.5.0
 homepage: https://github.com/ja2375/add_2_calendar
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: add_2_calendar
 description: A really simple Flutter plugin to add events to each platform's default calendar.
-version: 1.5.0
+version: 2.0.0
 homepage: https://github.com/ja2375/add_2_calendar
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ version: 1.4.0
 homepage: https://github.com/ja2375/add_2_calendar
 
 environment:
-  sdk: ">=2.0.0-dev.68.0 <3.0.0"
+  sdk: '>=2.12.0 <3.0.0'
   flutter: ">=1.10.0 <2.0.0"
 
 dependencies:


### PR DESCRIPTION
## Description
I propose this pull request to [migrate this plugin to null safety](https://dart.dev/null-safety/migration-guide) as it is the way to go now that Flutter 2 has been released.

Here are the changes I introduced:
* Update SDK dependency version to 2.12.0+
* Run `dart migrate` on existing code to remove unsafe nulls (package & example)
* Add a new version (`2.0.0`) to the changelog

### Related tickets
Closes #53