### PR TITLE
Add support for setting URL on iOS devices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 2.2.0
+* Add support for setting URL on iOS devices
+
 ## 2.1.3
 Flutter 2.10 support
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ final Event event = Event(
       endDate: DateTime(/* Some date here */),
       iosParams: IOSParams( 
         reminder: Duration(/* Ex. hours:1 */), // on iOS, you can set alarm notification after your event.
+        url: 'https://www.example.com', // on iOS, you can set url to your event.
       ),
       androidParams: AndroidParams( 
         emailInvites: [], // on Android, you can add invite emails to your event.

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -18,6 +18,7 @@ class MyApp extends StatelessWidget {
       allDay: false,
       iosParams: IOSParams(
         reminder: Duration(minutes: 40),
+        url: "http://example.com",
       ),
       androidParams: AndroidParams(
         emailInvites: ["test@example.com"],

--- a/ios/Classes/SwiftAdd2CalendarPlugin.swift
+++ b/ios/Classes/SwiftAdd2CalendarPlugin.swift
@@ -46,6 +46,8 @@ public class SwiftAdd2CalendarPlugin: NSObject, FlutterPlugin {
         let endDate = Date(milliseconds: (args["endDate"] as! Double))
         let alarmInterval = args["alarmInterval"] as? Double
         let allDay = args["allDay"] as! Bool
+        let url = args["url"] as! String
+        
         
         let eventStore = EKEventStore()
         
@@ -64,6 +66,7 @@ public class SwiftAdd2CalendarPlugin: NSObject, FlutterPlugin {
                 event.location = location
                 event.notes = description
                 event.isAllDay = allDay
+                event.url = URL(string: url);
                 
                 if let recurrence = args["recurrence"] as? [String:Any]{
                     let interval = recurrence["interval"] as! Int

--- a/lib/src/model/event.dart
+++ b/lib/src/model/event.dart
@@ -40,6 +40,7 @@ class Event {
 
     if (Platform.isIOS) {
       params['alarmInterval'] = iosParams.reminder?.inSeconds.toDouble();
+      params['url'] = iosParams.url;
     } else {
       params['invites'] = androidParams.emailInvites?.join(",");
     }
@@ -57,5 +58,6 @@ class AndroidParams {
 class IOSParams {
   //In iOS, you can set alert notification with duration. Ex. Duration(minutes:30) -> After30 min.
   final Duration? reminder;
-  const IOSParams({this.reminder});
+  final String? url;
+  const IOSParams({this.reminder, this.url});
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: add_2_calendar
 description: A really simple Flutter plugin to add events to each platform's default calendar.
-version: 2.1.3
+version: 2.2.0
 homepage: https://github.com/ja2375/add_2_calendar
 
 environment:


### PR DESCRIPTION
This PR adds support for setting the [url](https://developer.apple.com/documentation/eventkit/ekcalendaritem/1507265-url) `EKCalendarItem` property on iOS devices