### PR TITLE
fixed location overwriting description on android

### DIFF
--- a/android/src/main/kotlin/com/javih/add_2_calendar/Add2CalendarPlugin.kt
+++ b/android/src/main/kotlin/com/javih/add_2_calendar/Add2CalendarPlugin.kt
@@ -98,7 +98,7 @@ class Add2CalendarPlugin : FlutterPlugin, MethodCallHandler, ActivityAware {
         }
 
         if (loc != null) {
-            intent.putExtra(CalendarContract.Events.DESCRIPTION, loc)
+            intent.putExtra(CalendarContract.Events.LOCATION, loc)
         }
 
         intent.putExtra(CalendarContract.Events.EVENT_TIMEZONE, timeZone)


### PR DESCRIPTION
This should have fixed the calendar issue described here: https://github.com/ja2375/add_2_calendar/issues/118

My own tests worked this out fine. Basically what happened was:
<img width="546" alt="image" src="https://user-images.githubusercontent.com/48251866/204026422-8716b62e-97e0-4990-acd5-73779b275fe6.png">

^ the location, if it was not null, overwrote the description. Which caused issues. By changing .DESCRIPTION to .LOCATION this works now. The commit by c9e326c68308d62dfe4bf2d9d37c1b5da9210524 aaumond caused this issue, and this should be fixing it