### PR TITLE
Added "default" at presentCalendarModalToAddEvent function on Swift

### DIFF
--- a/ios/Classes/SwiftAdd2CalendarPlugin.swift
+++ b/ios/Classes/SwiftAdd2CalendarPlugin.swift
@@ -127,7 +127,7 @@ public class SwiftAdd2CalendarPlugin: NSObject, FlutterPlugin {
             // Auth denied or restricted
             completion?(false)
         default:
-        completion?(false)
+            completion?(false)
         }
     }
     


### PR DESCRIPTION
This PR fix the issue #127 - presentCalendarModalToAddEvent need a default switch case.
Include "default" into switch case on presentCalendarModalToAddEvent func, in SwiftAdd2CalendarPlugin class.