### PR TITLE
fix(build.gradle): remove duplicate compileOptions

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -65,8 +65,4 @@ android {
             }
         }
     }
-    compileOptions {
-        sourceCompatibility = 17
-        targetCompatibility = 17
-    }
 }


### PR DESCRIPTION
There was a bugged duplicate compileOptions category containing the ___Compatibility = 17 which needs to be removed