### PR TITLE
Fix callback for calendar modal on iOS 17

### DIFF
--- a/ios/Classes/Add2CalendarPlugin.swift
+++ b/ios/Classes/Add2CalendarPlugin.swift
@@ -102,6 +102,7 @@ public class Add2CalendarPlugin: NSObject, FlutterPlugin {
             OperationQueue.main.addOperation {
                 self.presentEventCalendarDetailModal(event: event, eventStore: eventStore)
             }
+            completion?(true)
         } else {
             let authStatus = getAuthorizationStatus()
             switch authStatus {


### PR DESCRIPTION
On iOS 17 devices callback about successful calendar modal opening doesn't work at the moment. Found out that this issue is already reported as #151, so here is a fix for it.

I saw that there is #150 but that one is much bigger and it is unknown if feedback for it would be addressed anytime soon.
In contrast, this PR just adds one missing line, so can be merged without worryies.

Fixes #151