### PR TITLE
fix: add missing switch cases

### DIFF
--- a/ios/Classes/Add2CalendarPlugin.swift
+++ b/ios/Classes/Add2CalendarPlugin.swift
@@ -105,7 +105,7 @@ public class Add2CalendarPlugin: NSObject, FlutterPlugin {
         } else {
             let authStatus = getAuthorizationStatus()
             switch authStatus {
-            case .authorized:
+            case .authorized, .fullAccess, .writeOnly:
                 OperationQueue.main.addOperation {
                     self.presentEventCalendarDetailModal(event: event, eventStore: eventStore)
                 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: add_2_calendar
 description: A really simple Flutter plugin to add events to each platform's default calendar.
-version: 3.0.1
+version: 3.1.1
 homepage: https://github.com/ja2375/add_2_calendar
 
 environment:


### PR DESCRIPTION
Xcode started to complain about missing switch cases on latest iOS versions (I'm not sure which version though). This PR should FIX the "Switch must be exhaustive" error that started to happen.

Resolves https://github.com/ja2375/add_2_calendar/pull/157

![image](https://github.com/ja2375/add_2_calendar/assets/4291391/4cbc7535-9c47-46d5-ad3f-4dac08aebcda)


