### PR TITLE
fix(android): apply Kotlin Android plugin for Gradle DSL

### DIFF
--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -2,14 +2,14 @@ group = "com.javih.add_2_calendar"
 version = "1.0-SNAPSHOT"
 
 buildscript {
-    val kotlinVersion = "2.3.20"
+    val kotlinVersion = "2.2.20"
     repositories {
         google()
         mavenCentral()
     }
 
     dependencies {
-        classpath("com.android.tools.build:gradle:9.0.1")
+        classpath("com.android.tools.build:gradle:8.11.1")
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion")
     }
 }

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -23,6 +23,7 @@ allprojects {
 
 plugins {
     id("com.android.library")
+    id("org.jetbrains.kotlin.android")
 }
 
 android {
@@ -67,7 +68,7 @@ android {
 
 kotlin {
     compilerOptions {
-        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
+        jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17)
     }
 }
 


### PR DESCRIPTION
## Summary
- Apply `org.jetbrains.kotlin.android` so the `kotlin { compilerOptions }` DSL resolves
- Use `jvmTarget.set(...)` for the Kotlin Gradle Property API
- Align plugin `buildscript` to AGP `8.11.1` / Kotlin `2.2.20` so Flutter 3.41 / AGP 8.x apps can build (AGP `9.0.1` was breaking those hosts)

## Context
- Fixes unresolved `kotlin` / `compilerOptions` / `jvmTarget` (#178)
- Related to AGP 9 being a breaking jump for older Flutter hosts (#177)

## Test plan
- [x] Flutter 3.41.9 app with AGP 8.11.1 builds Android debug successfully against this branch
- [x] Confirm `:add_2_calendar` Gradle script compiles without unresolved reference errors on a clean checkout

Fixes #178
Related #177